### PR TITLE
Add keyword-based matching for text input elements

### DIFF
--- a/Web/utils.js
+++ b/Web/utils.js
@@ -8,10 +8,16 @@
 
 /** Determines if current active element has editable text. */
 function activeElementHasEditableText() {
+    let activeElement = document.activeElement;
+    if (activeElement == null) return false;
+
+    // Matches with standard "INPUT" and "TEXTAREA" node names, as well as
+    // common keywords for custom input elements (e.g., Reddit search bar)
+    let keywords = ["INPUT", "TEXT", "SEARCH"];
+
     return (
-        document.activeElement.nodeName === "INPUT" ||
-        document.activeElement.nodeName === "TEXTAREA" ||
-        document.activeElement.isContentEditable
+        activeElement.isContentEditable ||
+        keywords.some(s => activeElement.nodeName.includes(s))
     );
 }
 


### PR DESCRIPTION
Some sites use custom HTML node names for text input, where the active element also isn't actually editable. This adds a generic approach for determining a text input element, e.g., Reddit's search bar's `<reddit-search-large>`. The occasional false positive shouldn't be an issue, since it wouldn't overlap with active `video` elements.

Closes #4