### PR TITLE
Optimize context menu validation

### DIFF
--- a/Web/core.js
+++ b/Web/core.js
@@ -101,7 +101,7 @@ function triggerAction(shortcut, event) {
         event.stopPropagation();
     }
 
-    logger.d("Action triggered", shortcut.description);
+    logger.d("Action triggered", shortcut.description, shortcut.keyCombo);
 
     // Actions independent of active video
     switch (shortcut.action) {

--- a/iOS/Common/Shortcut.swift
+++ b/iOS/Common/Shortcut.swift
@@ -56,9 +56,7 @@ struct Shortcut: Codable, Defaults.Serializable, Equatable, Identifiable {
         ].merging(action.dictionaryRepresentation) { current, _ in current }
     }
 
-    var description: String {
-        "\(action)"
-    }
+    var description: String { action.description }
 }
 
 // MARK: - Action Extensions

--- a/macOS/Accelerate Extension/SafariExtensionHandler.swift
+++ b/macOS/Accelerate Extension/SafariExtensionHandler.swift
@@ -86,44 +86,12 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
     }
 
     override func validateContextMenuItem(withCommand command: String, in _: SFSafariPage, userInfo: [String: Any]? = nil, validationHandler: @escaping (Bool, String?) -> Void) {
-        guard let userInfo,
-            let isInitialized = userInfo["isInitialized"] as? Bool,
-            let hasVideos = userInfo["hasVideos"] as? Bool,
-            let currentRate = userInfo["currentRate"] as? Double
-        else {
-            validationHandler(true, nil)
-            return
-        }
-
-        if !isInitialized || !hasVideos {
-            validationHandler(true, nil)
-            return
-        }
-
-        if let index = Int(command), Defaults[.shortcuts].indices ~= index {
-            let shortcut = Defaults[.shortcuts][index]
-
-            if shortcut.showInContextMenu {
-                switch shortcut.action {
-                case let .setRate(rate):
-                    // Don't show context menu item for setRate actions if the current rate is already set to the associated value
-                    validationHandler(currentRate == (rate ?? Defaults[.defaultRate]), shortcut.action.description)
-                    return
-                default:
-                    validationHandler(false, shortcut.action.description)
-                    return
-                }
-            }
-        }
-
-        validationHandler(true, nil)
+        let description = userInfo?[command] as? String
+        validationHandler(description == nil, description)
     }
 
     override func contextMenuItemSelected(withCommand command: String, in page: SFSafariPage, userInfo _: [String: Any]? = nil) {
-        if let index = Int(command), Defaults[.shortcuts].indices ~= index {
-            let shortcut = Defaults[.shortcuts][index]
-            page.triggerAction(for: shortcut)
-        }
+        page.triggerContextMenuAction(for: command)
     }
 
     override func popoverViewController() -> SFSafariExtensionViewController {

--- a/macOS/Common/Shortcut.swift
+++ b/macOS/Common/Shortcut.swift
@@ -59,6 +59,7 @@ struct Shortcut: Codable, Defaults.Serializable {
             "isEnabled": isEnabled,
             "isGlobal": isGlobal,
             "showSnackbar": showSnackbar,
+            "showInContextMenu": showInContextMenu,
             "description": description,
         ].merging(action.dictionaryRepresentation) { current, _ in current }
     }
@@ -68,9 +69,7 @@ struct Shortcut: Codable, Defaults.Serializable {
 
 /// Based on https://github.com/sindresorhus/KeyboardShortcuts/blob/main/Sources/KeyboardShortcuts/Shortcut.swift
 extension Shortcut: CustomStringConvertible {
-    var description: String {
-        "\(action) - \(keyComboString)"
-    }
+    var description: String { action.description }
 
     var keyComboString: String {
         "\(modifiers)\(keyEquivalent)"

--- a/macOS/Extensions/Safari+Extensions.swift
+++ b/macOS/Extensions/Safari+Extensions.swift
@@ -13,6 +13,10 @@ extension SFSafariPage {
     func triggerAction(for shortcut: Shortcut) {
         dispatchMessageToScript(withName: "triggerAction", userInfo: ["shortcut": shortcut.dictionaryRepresentation])
     }
+    
+    func triggerContextMenuAction(for command: String) {
+        dispatchMessageToScript(withName: "triggerContextMenuAction", userInfo: ["index": Int(command)!])
+    }
 
     func isAllowed(completion: @escaping (_ isAllowed: Bool, _ rule: String?) -> Void) {
         getPropertiesWithCompletionHandler { properties in


### PR DESCRIPTION
Close #18. Optimizes validation handler to reduce repeated logic.

Time in nanoseconds to invoke callback from `validateContextMenuItem`:

| | Before | After |
| -|-|-|
| Mean | 208,003.87 | 11,215.7 |
| Median | 110,333.0 | 8,208.0 |