### PR TITLE
Fix toolbar action when set to None

### DIFF
--- a/macOS/Accelerate Extension/SafariExtensionHandler.swift
+++ b/macOS/Accelerate Extension/SafariExtensionHandler.swift
@@ -75,6 +75,11 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
     }
 
     override func validateToolbarItem(in window: SFSafariWindow, validationHandler: @escaping ((Bool, String) -> Void)) {
+        if Defaults[.shortcuts].toolbarShortcutIndex == nil {
+            validationHandler(false, "")
+            return
+        }
+
         // This is called when Safari's state changed in some way that would require the extension's toolbar item to be validated again.
         window.getActiveTab { tab in
             tab?.getActivePage { page in

--- a/macOS/Extensions/Defaults+Keys.swift
+++ b/macOS/Extensions/Defaults+Keys.swift
@@ -16,7 +16,7 @@ extension Defaults {
 
 extension Defaults.Keys {
     // Identifier of shortcut associated with the toolbar
-    static let toolbarShortcutIdentifier = Key<String?>("toolbarShortcut", default: "FF7BF0BE-5DDC-4FFE-84CF-F5056A993A1A", suite: Defaults.suite)
+    static let toolbarShortcutIdentifier = Key<String?>("toolbarShortcut", default: nil, suite: Defaults.suite)
 
     // Array of shortcut preference keys
     static let allShortcutKeys: [Defaults.Keys] = [.shortcuts, .toolbarShortcutIdentifier]


### PR DESCRIPTION
Closes #22

- Removes hard-coded default identifier for `toolbarShortcutIndex` which would be used when setting value to `nil` (i.e., None)
- Disable toolbar button if no shortcut set
